### PR TITLE
task/HW-59554-Use-last_git_tag-instead-of-get_version_number-in-UI-SDK-and-Insights-SDK

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,7 +14,7 @@ lane :release do
 end
 
 def updateVersion(type)
-  version = get_version_number(target: "Insights")
+  version = last_git_tag
   if type == "beta" then
     version_components = version.split("beta")
     last_component = Integer(version_components[-1]) + 1
@@ -32,7 +32,6 @@ def update(type, version)
   pod_lib_lint(allow_warnings: true, skip_tests: true)
   version_bump_podspec(version_number: version, path: podspec_name)
   increment_version_number(version_number: version)
-  get_version_number(target: "Insights")
   git_add(path: podspec_name)
   git_add(path: "**/Info.plist")
   git_commit(path: [podspec_name, "**/Info.plist"],


### PR DESCRIPTION
Added last_git_tag and removed get_version_number from update method